### PR TITLE
Introduce cheatcalls client in tests

### DIFF
--- a/spec-tests/src/evm_setNextBlockTimestamp.test.ts
+++ b/spec-tests/src/evm_setNextBlockTimestamp.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from 'node:assert'
 import { describe, it } from 'node:test'
 import { mainnet } from 'viem/chains'
 import { multicall3Abi } from './harness/abis/multicall3'
-import { setupTestingHarness } from './harness/setupTestingEnvironment'
+import { setupTestHarness } from './harness/setupTestingEnvironment'
 import { sleep } from './utils/sleep'
 
 const blockInfo = {
@@ -12,7 +12,7 @@ const blockInfo = {
 
 describe('evm_setNextBlockTimestamp', () => {
   it('should set the next block timestamp', async () => {
-    await using harness = await setupTestingHarness({
+    await using harness = await setupTestHarness({
       originForkNetworkChainId: 1,
       forkChainId: 1337,
       forkBlockNumber: blockInfo.blockNumber,
@@ -37,7 +37,7 @@ describe('evm_setNextBlockTimestamp', () => {
   })
 
   it('should provide the next timestamp during eth_call for pending blocks', async () => {
-    await using harness = await setupTestingHarness({
+    await using harness = await setupTestHarness({
       originForkNetworkChainId: 1,
       forkChainId: 1337,
       forkBlockNumber: blockInfo.blockNumber,
@@ -57,7 +57,7 @@ describe('evm_setNextBlockTimestamp', () => {
   })
 
   it('should not mine new block immediately', async () => {
-    await using harness = await setupTestingHarness({
+    await using harness = await setupTestHarness({
       originForkNetworkChainId: 1,
       forkChainId: 1337,
       forkBlockNumber: blockInfo.blockNumber,
@@ -73,7 +73,7 @@ describe('evm_setNextBlockTimestamp', () => {
   })
 
   it('should set the exact next block timestamp even after a delay', { timeout: 10_000 }, async () => {
-    await using harness = await setupTestingHarness({
+    await using harness = await setupTestHarness({
       originForkNetworkChainId: 1,
       forkChainId: 1337,
       forkBlockNumber: blockInfo.blockNumber,

--- a/spec-tests/src/harness/index.ts
+++ b/spec-tests/src/harness/index.ts
@@ -1,1 +1,1 @@
-export { setupTestingHarness as setupTestingEnvironment } from './setupTestingEnvironment'
+export { setupTestHarness as setupTestingEnvironment } from './setupTestingEnvironment'

--- a/spec-tests/src/harness/nodes/types.ts
+++ b/spec-tests/src/harness/nodes/types.ts
@@ -1,3 +1,5 @@
+import { Chain, Transport } from 'viem'
+
 export interface ForkOptions {
   originForkNetworkChainId: number
   forkChainId: number
@@ -7,4 +9,10 @@ export interface ForkOptions {
 export interface IForkNode {
   start(forkOptions: ForkOptions): Promise<void>
   stop(): Promise<void>
+
+  getCheatcallsClient(chain: Chain, transport: Transport): CheatcallsClient
+}
+
+export interface CheatcallsClient {
+  setNextBlockTimestamp({ timestamp }: { timestamp: bigint }): Promise<void>
 }


### PR DESCRIPTION
This allows us to test current nodes interface but in the future easily switch to test `cheat_` prefixed methods. 